### PR TITLE
feat/14/get move locations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,6 +43,7 @@
     "treosh",
     "zhuangtongfa"
   ],
+  "cSpell.ignorePaths": ["*.spec.ts"],
   // force logging to be enabled
   "angular.log": "verbose",
   // allow eslint to use more memory to improve performance for

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,6 +37,7 @@
     "peaceiris",
     "preconnect",
     "s",
+    "Strs",
     "svgviewer",
     "Taniguchi's",
     "treosh",

--- a/libs/game/src/index.ts
+++ b/libs/game/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/models';
+export * from './lib/utils';

--- a/libs/game/src/lib/models/board/board-grid.spec.ts
+++ b/libs/game/src/lib/models/board/board-grid.spec.ts
@@ -1,4 +1,4 @@
-import { createGrid, getFromGrid, isBoardGrid } from './board-grid';
+import { createGrid, getFromGrid, updateGrid, isBoardGrid } from './board-grid';
 import { BoardX } from './board-x';
 import { BoardY } from './board-y';
 
@@ -30,4 +30,53 @@ describe('getFromGrid', () => {
       // provided to verify we are getting the actual value.
       value: 'test',
     }));
+});
+
+describe('updateGrid', () => {
+  test('returns new grid reference', () => {
+    const originalBoardGrid = createGrid();
+
+    const updatedBoardGrid = updateGrid({
+      board: originalBoardGrid,
+      location: {
+        x: BoardX(5),
+        y: BoardY(5),
+      },
+      cell: 'whatever',
+    });
+
+    expect(originalBoardGrid === updatedBoardGrid).toEqual(false);
+  });
+  test('updates grid with new cell', () => {
+    const originalBoardGrid = createGrid();
+
+    const updatedBoardGrid = updateGrid({
+      board: originalBoardGrid,
+      location: {
+        x: BoardX(5),
+        y: BoardY(5),
+      },
+      cell: 'whatever',
+    });
+
+    expect(updatedBoardGrid[5][5]).toEqual('whatever');
+  });
+  test('keeps unaffected row reference', () => {
+    const originalBoardGrid = createGrid();
+
+    const originalBoardRow2 = originalBoardGrid[2];
+
+    const updatedBoardGrid = updateGrid({
+      board: originalBoardGrid,
+      location: {
+        x: BoardX(5),
+        y: BoardY(5),
+      },
+      cell: 'whatever',
+    });
+
+    const updatedBoardRow2 = updatedBoardGrid[2];
+
+    expect(originalBoardRow2 === updatedBoardRow2).toEqual(true);
+  });
 });

--- a/libs/game/src/lib/models/board/board-grid.ts
+++ b/libs/game/src/lib/models/board/board-grid.ts
@@ -41,6 +41,27 @@ type CreateGrid = {
 };
 
 /**
+ * Updates the grid with the given board-location and cell. Will
+ * return the updated grid, with the new cell.
+ */
+export const updateGrid = <BoardCell = unknown>({
+  board,
+  location: { x, y },
+  cell,
+}: {
+  board: BoardGrid<BoardCell>;
+  location: BoardLocation;
+  cell: BoardCell;
+}): BoardGrid<BoardCell> =>
+  board.map((boardRow, rowIndex) =>
+    rowIndex === y
+      ? boardRow.map((boardCell, cellIndex) =>
+          cellIndex === x ? cell : boardCell
+        )
+      : boardRow
+  );
+
+/**
  * Factory function that creates a basic grid.
  * Will be populated by `undefined` if no `cellFactory` is given.
  */

--- a/libs/game/src/lib/models/board/near-location.ts
+++ b/libs/game/src/lib/models/board/near-location.ts
@@ -39,3 +39,17 @@ export const getNearLocations = <BoardCell = unknown>(
     ? getFromGrid(board, { x: BoardX(x - 1), y })
     : undefined,
 });
+
+/**
+ * Returns the board-locations near the given board-location that
+ * are valid.
+ */
+export const getNearLocationCoords = ({
+  x,
+  y,
+}: BoardLocation): Record<Direction, BoardLocation | undefined> => ({
+  north: isBoardY(y - 1) ? { x, y: BoardY(y - 1) } : undefined,
+  south: isBoardY(y + 1) ? { x, y: BoardY(y + 1) } : undefined,
+  east: isBoardX(x + 1) ? { x: BoardX(x + 1), y } : undefined,
+  west: isBoardX(x - 1) ? { x: BoardX(x - 1), y } : undefined,
+});

--- a/libs/game/src/lib/utils/board-to-str/board-to-str.spec.ts
+++ b/libs/game/src/lib/utils/board-to-str/board-to-str.spec.ts
@@ -1,0 +1,45 @@
+import { createGrid } from '../../models/board/board-grid';
+import { boardToStr, cellToOChar } from './board-to-str';
+
+describe('boardToStr', () => {
+  test('returns O/empty board of the correct size', () =>
+    expect(
+      boardToStr({
+        board: createGrid(),
+        cellToStr: cellToOChar,
+      })
+    ).toEqual(`OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO`));
+  test('returns O/empty board of the correct size, with new line', () =>
+    expect(
+      boardToStr({
+        board: createGrid(),
+        cellToStr: cellToOChar,
+        startWithNewLine: true,
+      })
+    ).toEqual(`
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO`));
+  // TODO: needs the "addToGrid" function
+  test.todo('plane is rendered at X in O grid');
+});

--- a/libs/game/src/lib/utils/board-to-str/board-to-str.spec.ts
+++ b/libs/game/src/lib/utils/board-to-str/board-to-str.spec.ts
@@ -1,4 +1,5 @@
-import { createGrid } from '../../models/board/board-grid';
+import { BoardX, BoardY } from '../../models/board';
+import { createGrid, updateGrid } from '../../models/board/board-grid';
 import { boardToStr, cellToOChar } from './board-to-str';
 
 describe('boardToStr', () => {
@@ -40,6 +41,32 @@ OOOOOOOOOO
 OOOOOOOOOO
 OOOOOOOOOO
 OOOOOOOOOO`));
-  // TODO: needs the "addToGrid" function
-  test.todo('plane is rendered at X in O grid');
+  test('cell is rendered at X in O grid', () =>
+    expect(
+      boardToStr({
+        board: updateGrid({
+          board: createGrid(),
+          location: {
+            x: BoardX(5),
+            y: BoardY(5),
+          },
+          cell: 'X',
+        }),
+        // keep value, or return O if nothing is given
+        cellToStr: (cell) => cell || 'O',
+        startWithNewLine: true,
+      })
+    ).toEqual(`
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOXOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO`));
 });

--- a/libs/game/src/lib/utils/board-to-str/board-to-str.ts
+++ b/libs/game/src/lib/utils/board-to-str/board-to-str.ts
@@ -1,0 +1,42 @@
+import { BoardGrid } from '../../models/board/board-grid';
+
+/**
+ * Returns the board as a text representation of single characters.
+ *
+ * Useful to help visually debug board states.
+ */
+export const boardToStr = <BoardCell = unknown>({
+  board,
+  cellToStr,
+  startWithNewLine,
+}: {
+  /**
+   * The board we are to print
+   */
+  board: BoardGrid<BoardCell>;
+  /**
+   * Function that can be provided to convert a given board cell to
+   * a single character string.
+   *
+   * If the return value isn't a single character string, this
+   * function will throw an error.
+   */
+  cellToStr: (cell: BoardCell) => string;
+  /**
+   * Flag that can be passed to automatically add a newline at the start
+   * of the string. This can help align the board string during testing.
+   */
+  startWithNewLine?: boolean;
+}): string =>
+  (startWithNewLine ? '\n' : '') +
+  board
+    .map((boardRow) =>
+      boardRow.map((boardCell) => cellToStr(boardCell)).join('')
+    )
+    .join('\n');
+
+/**
+ * Essentially a placeholder function that can be passed to the `cellToStr`
+ * function and will return the character of `O`. Useful for testing.
+ */
+export const cellToOChar = (): string => 'O';

--- a/libs/game/src/lib/utils/index.ts
+++ b/libs/game/src/lib/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './on-move/get-move-locations';

--- a/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
@@ -1,6 +1,48 @@
+import {
+  BoardLocation,
+  BoardX,
+  BoardY,
+  getBoardLocationString,
+} from '../../models/board';
+import { createTestPlane } from '../../models/plane/plane';
+import { getMoveLocations } from './get-move-locations';
+
 describe('getMoveLocations', () => {
   describe('roll of 1', () => {
-    test.todo('returns 4 moves');
+    test('returns 4 moves', () => {
+      const boardLocations: BoardLocation[] = [
+        {
+          // North
+          x: BoardX(5),
+          y: BoardY(4),
+        },
+        {
+          // South
+          x: BoardX(5),
+          y: BoardY(6),
+        },
+        {
+          // East
+          x: BoardX(6),
+          y: BoardY(5),
+        },
+        {
+          // West
+          x: BoardX(4),
+          y: BoardY(5),
+        },
+      ];
+      expect(
+        getMoveLocations({
+          plane: { ...createTestPlane(), x: BoardX(5), y: BoardY(5) },
+          dice: 1,
+          inFlightPlanes: [],
+        })
+      ).toEqual({
+        boardLocations,
+        boardLocationStrs: boardLocations.map(getBoardLocationString),
+      });
+    });
     test.todo('returns 3 moves, when plane is adjacent');
   });
 

--- a/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
@@ -334,30 +334,120 @@ OOOOOOOOOO`,
       expect(boardLocationStrs.includes(BoardLocationStr('5-5'))).toEqual(true);
     });
 
-    test.todo('returns moves no including the side');
+    test('returns moves no including the side', () =>
+      visualCheck({
+        dice: 2,
+        // Starts at the middle bottom
+        startLocation: { x: BoardX(5), y: BoardY(11) },
+        expected: `
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOXOOOO
+OOOOXOXOOO
+OOOXOSOXOO`,
+      }));
   });
 
   describe('roll of 3', () => {
-    test.todo('returns 16 moves');
-    test.todo('returns ?? moves, when plane is adjacent');
-    test.todo('returns less moves, when plane is on the side of the board');
-  });
-
-  describe('roll of 4', () => {
-    test.todo('returns 25 moves (can go back to the start square)');
-    test.todo('returns ?? moves, when plane is adjacent');
-    test.todo('returns less moves, when plane is on the side of the board');
-  });
-
-  describe('roll of 5', () => {
-    test.todo('returns 36 moves');
-    test.todo('returns ?? moves, when plane is adjacent');
-    test.todo('returns less moves, when plane is on the side of the board');
+    test('returns 16 moves', () =>
+      visualCheck({
+        dice: 3,
+        startLocation: { x: BoardX(5), y: BoardY(5) },
+        expected: `
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOXOOOO
+OOOOXOXOOO
+OOOXOXOXOO
+OOXOXSXOXO
+OOOXOXOXOO
+OOOOXOXOOO
+OOOOOXOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO`,
+      }));
+    test('returns moves, when plane is adjacent', () =>
+      visualCheck({
+        dice: 3,
+        // Start closer to the corner
+        startLocation: { x: BoardX(2), y: BoardY(2) },
+        inFlightPlanes: [
+          {
+            // Directly west
+            x: BoardX(1),
+            y: BoardY(2),
+          },
+          {
+            // South to the east
+            x: BoardX(3),
+            y: BoardY(3),
+          },
+          {
+            // South 2
+            x: BoardX(2),
+            y: BoardY(4),
+          },
+        ],
+        expected: `
+OXOXOOOOOO
+XOXOXOOOOO
+OOSXOXOOOO
+XOXOXOOOOO
+OXOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO`,
+      }));
   });
 
   describe('roll of 6', () => {
-    test.todo('returns 49 moves (can go back to the start square)');
-    test.todo('returns ?? moves, when plane is adjacent');
-    test.todo('returns less moves, when plane is on the side of the board');
+    test('returns 49 moves (can go back to the start square)', () =>
+      visualCheck({
+        dice: 6,
+        // Start closer to the corner
+        startLocation: { x: BoardX(3), y: BoardY(4) },
+        inFlightPlanes: [
+          {
+            // West and North
+            x: BoardX(1),
+            y: BoardY(2),
+          },
+          {
+            // Directly North
+            x: BoardX(3),
+            y: BoardY(3),
+          },
+          {
+            // Far
+            x: BoardX(8),
+            y: BoardY(8),
+          },
+        ],
+        expected: `
+OXOXOXOOOO
+XOXOXOXOOO
+OOOXOXOXOO
+XOXOXOXOXO
+OXOSOXOXOX
+XOXOXOXOXO
+OXOXOXOXOO
+XOXOXOXOOO
+OXOXOXOOOO
+OOXOXOOOOO
+OOOXOOOOOO
+OOOOOOOOOO`,
+      }));
   });
 });

--- a/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
@@ -2,9 +2,13 @@ import {
   BoardLocation,
   BoardX,
   BoardY,
+  createGrid,
   getBoardLocationString,
+  isBoardLocationEq,
+  updateGrid,
 } from '../../models/board';
 import { createTestPlane } from '../../models/plane/plane';
+import { boardToStr } from '../board-to-str/board-to-str';
 import { getMoveLocations } from './get-move-locations';
 
 describe('getMoveLocations', () => {
@@ -109,7 +113,64 @@ describe('getMoveLocations', () => {
   });
 
   describe('roll of 2', () => {
-    test.todo('returns 9 moves (can go back to start square)');
+    test.only('returns 9 moves (can go back to start square)', () => {
+      const boardLocations: BoardLocation[] = [] as BoardLocation[];
+      const boardLocationStrs = boardLocations.map(getBoardLocationString);
+      const startLocation = { x: BoardX(5), y: BoardY(5) };
+      expect(
+        getMoveLocations({
+          // Plane cannot move north as its already north enough.
+          plane: createTestPlane(startLocation),
+          dice: 2,
+          inFlightPlanes: [],
+        })
+      ).toEqual({
+        boardLocations,
+        boardLocationStrs,
+      });
+
+      // Visual check
+      expect(
+        boardToStr({
+          board: boardLocations.reduce(
+            (board, boardLocation) =>
+              updateGrid({
+                board,
+                location: boardLocation,
+                cell: isBoardLocationEq(boardLocation, startLocation)
+                  ? 'S'
+                  : 'X',
+              }),
+            updateGrid({
+              board: createGrid(() => 'O'),
+              location: startLocation,
+              cell: 'S',
+            })
+          ),
+          startWithNewLine: true,
+          cellToStr: (cell) => cell,
+        })
+      ).toEqual(`
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOXOOOO
+OOOOXOXOOO
+OOOXOSOXOO
+OOOOXOXOOO
+OOOOOXOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO`);
+
+      // Has 9 possible moves
+      expect(boardLocationStrs.length).toBe(9);
+
+      // No duplicates
+      const noDupesSet = Array.from(new Set(boardLocationStrs).values());
+      expect(noDupesSet.length).toEqual(boardLocationStrs.length);
+    });
     test.todo('returns 8 moves, when plane is adjacent');
   });
 

--- a/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
@@ -1,0 +1,27 @@
+describe('getMoveLocations', () => {
+  describe('roll of 1', () => {
+    test.todo('returns 4 moves');
+    test.todo('returns 3 moves, but plane is adjacent');
+  });
+
+  describe('roll of 2', () => {
+    test.todo('returns 9 moves (can go back to start square)');
+    test.todo('returns 8 moves, but plane is adjacent');
+  });
+
+  describe('roll of 3', () => {
+    test.todo('returns 16 moves');
+  });
+
+  describe('roll of 4', () => {
+    test.todo('returns 25 moves (can go back to the start square)');
+  });
+
+  describe('roll of 5', () => {
+    test.todo('returns 36 moves');
+  });
+
+  describe('roll of 6', () => {
+    test.todo('returns 49 moves (can go back to the start square)');
+  });
+});

--- a/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
@@ -1,5 +1,6 @@
 import {
   BoardLocation,
+  BoardLocationStr,
   BoardX,
   BoardY,
   createGrid,
@@ -7,7 +8,7 @@ import {
   isBoardLocationEq,
   updateGrid,
 } from '../../models/board';
-import { createTestPlane } from '../../models/plane/plane';
+import {} from '../../models/plane/plane';
 import { boardToStr } from '../board-to-str/board-to-str';
 import { getMoveLocations } from './get-move-locations';
 
@@ -38,7 +39,7 @@ describe('getMoveLocations', () => {
       ];
       expect(
         getMoveLocations({
-          plane: { ...createTestPlane(), x: BoardX(5), y: BoardY(5) },
+          plane: { x: BoardX(5), y: BoardY(5) },
           dice: 1,
           inFlightPlanes: [],
         })
@@ -67,12 +68,12 @@ describe('getMoveLocations', () => {
       ];
       expect(
         getMoveLocations({
-          plane: createTestPlane({ x: BoardX(5), y: BoardY(5) }),
+          plane: { x: BoardX(5), y: BoardY(5) },
           dice: 1,
           inFlightPlanes: [
             // This plane is "north" of the starting plane,
             // thus preventing our plane from trying to move there
-            createTestPlane({ x: BoardX(5), y: BoardY(4) }),
+            { x: BoardX(5), y: BoardY(4) },
           ],
         })
       ).toEqual({
@@ -98,11 +99,11 @@ describe('getMoveLocations', () => {
       expect(
         getMoveLocations({
           // Plane cannot move north as its already north enough.
-          plane: createTestPlane({ x: BoardX(3), y: BoardY(0) }),
+          plane: { x: BoardX(3), y: BoardY(0) },
           dice: 1,
           inFlightPlanes: [
             // This plane is elsewhere and not important.
-            createTestPlane({ x: BoardX(5), y: BoardY(5) }),
+            { x: BoardX(5), y: BoardY(5) },
           ],
         })
       ).toEqual({
@@ -157,7 +158,7 @@ describe('getMoveLocations', () => {
       expect(
         getMoveLocations({
           // Plane cannot move north as its already north enough.
-          plane: createTestPlane(startLocation),
+          plane: startLocation,
           dice: 2,
           inFlightPlanes: [],
         })
@@ -208,7 +209,103 @@ OOOOOOOOOO`);
       const noDupesSet = Array.from(new Set(boardLocationStrs).values());
       expect(noDupesSet.length).toEqual(boardLocationStrs.length);
     });
-    test.todo('returns 8 moves, when plane is adjacent');
+    test('returns 8 moves, when plane is adjacent', () => {
+      const boardLocations: BoardLocation[] = [
+        {
+          x: 5,
+          y: 3,
+        },
+        {
+          x: 5,
+          y: 5,
+        },
+        {
+          x: 6,
+          y: 4,
+        },
+        {
+          x: 4,
+          y: 4,
+        },
+        {
+          x: 6,
+          y: 6,
+        },
+        {
+          x: 7,
+          y: 5,
+        },
+        {
+          x: 4,
+          y: 6,
+        },
+        {
+          x: 3,
+          y: 5,
+        },
+      ] as BoardLocation[];
+      const boardLocationStrs = boardLocations.map(getBoardLocationString);
+      const startLocation = { x: BoardX(5), y: BoardY(5) };
+      // const
+      expect(
+        getMoveLocations({
+          // Plane cannot move north as its already north enough.
+          plane: startLocation,
+          dice: 2,
+          inFlightPlanes: [
+            // Below the plane
+            { x: BoardX(5), y: BoardY(6) },
+          ],
+        })
+      ).toEqual({
+        boardLocations,
+        boardLocationStrs,
+      });
+      // Visual check
+      expect(
+        boardToStr({
+          board: boardLocations.reduce(
+            (board, boardLocation) =>
+              updateGrid({
+                board,
+                location: boardLocation,
+                cell: isBoardLocationEq(boardLocation, startLocation)
+                  ? 'S'
+                  : 'X',
+              }),
+            updateGrid({
+              board: createGrid(() => 'O'),
+              location: startLocation,
+              cell: 'S',
+            })
+          ),
+          startWithNewLine: true,
+          cellToStr: (cell) => cell,
+        })
+      ).toEqual(`
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOXOOOO
+OOOOXOXOOO
+OOOXOSOXOO
+OOOOXOXOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO
+OOOOOOOOOO`);
+
+      // Has 8 possible moves
+      expect(boardLocationStrs.length).toBe(8);
+
+      // No duplicates
+      const noDupesSet = Array.from(new Set(boardLocationStrs).values());
+      expect(noDupesSet.length).toEqual(boardLocationStrs.length);
+
+      // Includes starting position
+      expect(boardLocationStrs.includes(BoardLocationStr('5-5'))).toEqual(true);
+    });
   });
 
   describe('roll of 3', () => {

--- a/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
@@ -43,7 +43,69 @@ describe('getMoveLocations', () => {
         boardLocationStrs: boardLocations.map(getBoardLocationString),
       });
     });
-    test.todo('returns 3 moves, when plane is adjacent');
+    test('returns 3 moves, when plane is adjacent', () => {
+      const boardLocations: BoardLocation[] = [
+        {
+          // South
+          x: BoardX(5),
+          y: BoardY(6),
+        },
+        {
+          // East
+          x: BoardX(6),
+          y: BoardY(5),
+        },
+        {
+          // West
+          x: BoardX(4),
+          y: BoardY(5),
+        },
+      ];
+      expect(
+        getMoveLocations({
+          plane: createTestPlane({ x: BoardX(5), y: BoardY(5) }),
+          dice: 1,
+          inFlightPlanes: [
+            // This plane is "north" of the starting plane,
+            // thus preventing our plane from trying to move there
+            createTestPlane({ x: BoardX(5), y: BoardY(4) }),
+          ],
+        })
+      ).toEqual({
+        boardLocations,
+        boardLocationStrs: boardLocations.map(getBoardLocationString),
+      });
+    });
+    test('returns 3 moves when at the edge of the map', () => {
+      const boardLocations: BoardLocation[] = [
+        {
+          x: BoardX(3),
+          y: BoardY(1),
+        },
+        {
+          x: BoardX(4),
+          y: BoardY(0),
+        },
+        {
+          x: BoardX(2),
+          y: BoardY(0),
+        },
+      ];
+      expect(
+        getMoveLocations({
+          // Plane cannot move north as its already north enough.
+          plane: createTestPlane({ x: BoardX(3), y: BoardY(0) }),
+          dice: 1,
+          inFlightPlanes: [
+            // This plane is elsewhere and not important.
+            createTestPlane({ x: BoardX(5), y: BoardY(5) }),
+          ],
+        })
+      ).toEqual({
+        boardLocations,
+        boardLocationStrs: boardLocations.map(getBoardLocationString),
+      });
+    });
   });
 
   describe('roll of 2', () => {

--- a/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
@@ -113,8 +113,45 @@ describe('getMoveLocations', () => {
   });
 
   describe('roll of 2', () => {
-    test.only('returns 9 moves (can go back to start square)', () => {
-      const boardLocations: BoardLocation[] = [] as BoardLocation[];
+    test('returns 9 moves (can go back to start square)', () => {
+      const boardLocations: BoardLocation[] = [
+        {
+          x: 5,
+          y: 3,
+        },
+        {
+          x: 5,
+          y: 5,
+        },
+        {
+          x: 6,
+          y: 4,
+        },
+        {
+          x: 4,
+          y: 4,
+        },
+        {
+          x: 5,
+          y: 7,
+        },
+        {
+          x: 6,
+          y: 6,
+        },
+        {
+          x: 4,
+          y: 6,
+        },
+        {
+          x: 7,
+          y: 5,
+        },
+        {
+          x: 3,
+          y: 5,
+        },
+      ] as BoardLocation[];
       const boardLocationStrs = boardLocations.map(getBoardLocationString);
       const startLocation = { x: BoardX(5), y: BoardY(5) };
       expect(

--- a/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
@@ -1,27 +1,31 @@
 describe('getMoveLocations', () => {
   describe('roll of 1', () => {
     test.todo('returns 4 moves');
-    test.todo('returns 3 moves, but plane is adjacent');
+    test.todo('returns 3 moves, when plane is adjacent');
   });
 
   describe('roll of 2', () => {
     test.todo('returns 9 moves (can go back to start square)');
-    test.todo('returns 8 moves, but plane is adjacent');
+    test.todo('returns 8 moves, when plane is adjacent');
   });
 
   describe('roll of 3', () => {
     test.todo('returns 16 moves');
+    test.todo('returns ?? moves, when plane is adjacent');
   });
 
   describe('roll of 4', () => {
     test.todo('returns 25 moves (can go back to the start square)');
+    test.todo('returns ?? moves, when plane is adjacent');
   });
 
   describe('roll of 5', () => {
     test.todo('returns 36 moves');
+    test.todo('returns ?? moves, when plane is adjacent');
   });
 
   describe('roll of 6', () => {
     test.todo('returns 49 moves (can go back to the start square)');
+    test.todo('returns ?? moves, when plane is adjacent');
   });
 });

--- a/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.spec.ts
@@ -306,25 +306,31 @@ OOOOOOOOOO`);
       // Includes starting position
       expect(boardLocationStrs.includes(BoardLocationStr('5-5'))).toEqual(true);
     });
+
+    test.todo('returns moves no including the side');
   });
 
   describe('roll of 3', () => {
     test.todo('returns 16 moves');
     test.todo('returns ?? moves, when plane is adjacent');
+    test.todo('returns less moves, when plane is on the side of the board');
   });
 
   describe('roll of 4', () => {
     test.todo('returns 25 moves (can go back to the start square)');
     test.todo('returns ?? moves, when plane is adjacent');
+    test.todo('returns less moves, when plane is on the side of the board');
   });
 
   describe('roll of 5', () => {
     test.todo('returns 36 moves');
     test.todo('returns ?? moves, when plane is adjacent');
+    test.todo('returns less moves, when plane is on the side of the board');
   });
 
   describe('roll of 6', () => {
     test.todo('returns 49 moves (can go back to the start square)');
     test.todo('returns ?? moves, when plane is adjacent');
+    test.todo('returns less moves, when plane is on the side of the board');
   });
 });

--- a/libs/game/src/lib/utils/on-move/get-move-locations.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.ts
@@ -13,7 +13,11 @@ import { Plane } from '../../models/plane/plane';
  * at the starting location.
  * 3. A plane cannot move through another plane.
  */
-export const getMoveLocations = (params: {
+export const getMoveLocations = ({
+  plane,
+  dice,
+  inFlightPlanes,
+}: {
   /**
    * The plane we are returning moves for.
    */
@@ -23,7 +27,7 @@ export const getMoveLocations = (params: {
    */
   dice: DiceSides;
   /**
-   *
+   * The list of planes currently in flight
    */
   inFlightPlanes: Plane[];
 }): {

--- a/libs/game/src/lib/utils/on-move/get-move-locations.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.ts
@@ -32,7 +32,7 @@ export const getMoveLocations = ({
   /**
    * The list of planes currently in flight
    */
-  inFlightPlanes: Plane[];
+  inFlightPlanes: Array<Pick<Plane, 'x' | 'y'>>;
 }): {
   /**
    * The locations the plane can move.
@@ -93,10 +93,7 @@ export const getMoveLocations = ({
       for (let i = 0; i < boardLocations.length; i++) {
         const boardLocationStr = boardLocationStrs[i];
         const boardLocation = boardLocations[i];
-        if (acc.boardLocationStrs.includes(boardLocationStr)) {
-          // If the location is already included, then don't include it again
-          continue;
-        }
+        if (acc.boardLocationStrs.includes(boardLocationStr)) continue;
         acc.boardLocations.push(boardLocation);
         acc.boardLocationStrs.push(boardLocationStr);
       }

--- a/libs/game/src/lib/utils/on-move/get-move-locations.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.ts
@@ -24,7 +24,7 @@ export const getMoveLocations = ({
   /**
    * The plane we are returning moves for.
    */
-  plane: Plane;
+  plane: Pick<Plane, 'x' | 'y'>;
   /**
    * The roll we are calculating moves for.
    */
@@ -76,6 +76,7 @@ export const getMoveLocations = ({
     )
   )
     landingSpots.push(west);
+
   if (nextDice <= 0)
     return {
       boardLocations: landingSpots,
@@ -85,7 +86,7 @@ export const getMoveLocations = ({
   return landingSpots.reduce(
     (acc, { x, y }) => {
       const { boardLocations, boardLocationStrs } = getMoveLocations({
-        plane: { ...plane, x, y },
+        plane: { x, y },
         dice: nextDice,
         inFlightPlanes,
       });
@@ -94,7 +95,7 @@ export const getMoveLocations = ({
         const boardLocation = boardLocations[i];
         if (acc.boardLocationStrs.includes(boardLocationStr)) {
           // If the location is already included, then don't include it again
-          return acc;
+          continue;
         }
         acc.boardLocations.push(boardLocation);
         acc.boardLocationStrs.push(boardLocationStr);

--- a/libs/game/src/lib/utils/on-move/get-move-locations.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.ts
@@ -2,6 +2,7 @@ import {
   BoardLocation,
   BoardLocationStr,
   getBoardLocationString,
+  isBoardLocationEq,
 } from '../../models/board/board-location';
 import { getNearLocationCoords } from '../../models/board/near-location';
 import { DiceSides } from '../../models/game-session/dice-sides';
@@ -57,10 +58,34 @@ export const getMoveLocations = (params: {
     const landingSpots: BoardLocation[] = [];
     const nextDice = (dice - 1) as DiceSides;
     const { north, south, east, west } = getNearLocationCoords(plane);
-    if (north) landingSpots.push(north);
-    if (south) landingSpots.push(south);
-    if (east) landingSpots.push(east);
-    if (west) landingSpots.push(west);
+    if (
+      north &&
+      !inFlightPlanes.find((inFlightPlane) =>
+        isBoardLocationEq(north, inFlightPlane)
+      )
+    )
+      landingSpots.push(north);
+    if (
+      south &&
+      !inFlightPlanes.find((inFlightPlane) =>
+        isBoardLocationEq(south, inFlightPlane)
+      )
+    )
+      landingSpots.push(south);
+    if (
+      east &&
+      !inFlightPlanes.find((inFlightPlane) =>
+        isBoardLocationEq(east, inFlightPlane)
+      )
+    )
+      landingSpots.push(east);
+    if (
+      west &&
+      !inFlightPlanes.find((inFlightPlane) =>
+        isBoardLocationEq(west, inFlightPlane)
+      )
+    )
+      landingSpots.push(west);
     if (nextDice <= 0) return landingSpots;
 
     return landingSpots.reduce(
@@ -75,6 +100,7 @@ export const getMoveLocations = (params: {
       [] as BoardLocation[]
     );
   };
+
   const boardLocations = getMoveLocations(params);
 
   return {

--- a/libs/game/src/lib/utils/on-move/get-move-locations.ts
+++ b/libs/game/src/lib/utils/on-move/get-move-locations.ts
@@ -1,0 +1,47 @@
+import {
+  BoardLocation,
+  BoardLocationStr,
+} from '../../models/board/board-location';
+import { DiceSides } from '../../models/game-session/dice-sides';
+import { Plane } from '../../models/plane/plane';
+
+/**
+ * Returns the available board-locations that the plane can move to.
+ *
+ * 1. A plane must move the entire dice roll.
+ * 2. A plane cannot move over the same location 2 times, except stopping
+ * at the starting location.
+ * 3. A plane cannot move through another plane.
+ */
+export const getMoveLocations = (params: {
+  /**
+   * The plane we are returning moves for.
+   */
+  plane: Plane;
+  /**
+   * The roll we are calculating moves for.
+   */
+  dice: DiceSides;
+  /**
+   *
+   */
+  inFlightPlanes: Plane[];
+}): {
+  /**
+   * The locations the plane can move.
+   */
+  boardLocations: BoardLocation[];
+  /**
+   * The location strings that the plane can move, this is provided more
+   * as a helper for situations where you need to perform lookups against
+   * what was returned, as the board-lookup-str
+   */
+  boardLocationStrs: BoardLocationStr[];
+} => {
+  // TODO:
+
+  return {
+    boardLocations: [],
+    boardLocationStrs: [],
+  };
+};


### PR DESCRIPTION
- Add test-cases for get-move-locations
- Add board-to-str basics
- add update grid function
- Add test for checking test
- Update test format for get-moe-locations
- Add working test-case for the basic 1 roll
- Add test-case for edge and with plane
- Start working on move-location logic
- Fix issue with board-location checks
- Add 2 move check
- Add more base test cases
- Add helper visualizer check function
- Finalize get-move-locations tests

**Which issue (if any) does this pull request address?**

Closes #14
